### PR TITLE
Add link about tracing from Tokio Blog to Step 3.8.

### DIFF
--- a/3_ecosystem/3_8_log/README.md
+++ b/3_ecosystem/3_8_log/README.md
@@ -50,6 +50,7 @@ Speaking of [tracing][10], the [`tracing`] crate has good integrations with [Ope
 For better understanding and familiarity with [`tracing`]'s design, concepts, usage, and features, read through the following articles:
 - [Official `tracing` crate docs][`tracing`]
 - [Yoav Danieli: Guide to OpenTelemetry Distributed Tracing in Rust][11]
+- [Tokio Blog: Diagnostics with Tracing][13]
 
 
 
@@ -112,3 +113,4 @@ After completing everything above, you should be able to answer (and understand 
 [10]: https://en.wikipedia.org/wiki/Tracing_(software)
 [11]: https://www.aspecto.io/blog/distributed-tracing-with-opentelemetry-rust
 [12]: https://www.thecodedmessage.com/posts/logging
+[13]: https://tokio.rs/blog/2019-08-tracing


### PR DESCRIPTION
I think it's worth adding this link to explain why it's sometimes more appropriate to use tracing instead of regular logging.