### PR TITLE
Fix deadline timestamps 00:00 -> 23:59

### DIFF
--- a/orientation.md
+++ b/orientation.md
@@ -132,14 +132,14 @@ Please be **respectful and polite** to peers and mentors.
 
 ### Deadlines
 
-__Soft Deadline: Thursday 00:00__
+__Soft Deadline: Thursday 23:59__
 - By this time, you should have submitted your latest version of the PR
 - If you do not do this, you get a foul
 - Mentors check your PR over the next day or two, and by Sunday you receive an aprove
 - 3 fouls received means expulsion from the bootcamp
 > 💡 If you still have corrections to make after Thursday, you can make them before the hard deadline - but this is also a foul (so try to have the final version of your PR by Thursday)
 
-__Hard deadline: Sunday 00:00__
+__Hard deadline: Sunday 23:59__
 - If by this time you still haven't submitted your PR or made the last edits, you are out of the bootcamp
 
 ### Expulsion


### PR DESCRIPTION
## Synopsis

In 24-hour clock format, 00:00 is considered to be the beginning of the day. Therefore, the deadlines would be at night between Wednesday and Thursday, not Thursday and Friday.




## Solution

Changed 00:00 to 23:59
