### PR TITLE
task_1_2: Repeat no Unpin requirement in task

### DIFF
--- a/1_concepts/1_2_box_pin/README.md
+++ b/1_concepts/1_2_box_pin/README.md
@@ -59,10 +59,9 @@ __Estimated time__: 1 day
    #### Important:
    ##### THERE HAS TO BE NO `unsafe` CODE (DON'T USE `unsafe`)
    > - `mut_me_somehow` must mutate self somehow.
-   > - You can add trait bounds to the types.
+   > - You can add trait bounds to the types. (using `Unpin` trait bound is not allowed)
    > - Write simple tests to demonstrate mut_me_somehow.
    > - you may use modules to avoid conflicting implementations
-  
 
    ```rust
    trait SayHi: fmt::Debug {


### PR DESCRIPTION
Right now, for part 1 of task_1_2, "`Unpin` is not allowed" is stated only in the code comment. This commonly leads to mistakes and revisions, therefore, here I'm repeating that `Unpin` is not allowed in the task description. 