### PR TITLE
Update workspace resolver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "1_concepts",
     "1_concepts/1_*",


### PR DESCRIPTION
The PR updates the workspace resolver to `2` to remove the annoying message on each build