### PR TITLE
Remove ambiguity in the first question of week 0

### DIFF
--- a/0_vocabulary/README.md
+++ b/0_vocabulary/README.md
@@ -12,7 +12,7 @@ Polish your familiarity by completing [Rust By Example] and [rustlings].
 Read through [Cargo Book] and become familiar with [Cargo] and its workspaces.
 
 After completing these steps, you should be able to answer (and understand why) the following questions:
-- What [memory model][31] [Rust] has? Is it single-threaded or multi-threaded? Is it synchronous or asynchronous? What are the memory layouts of `Box` and `Vector`? What are a heap and a stack? Where, but on heap and stack data could live in RAM?
+- What [memory model][31] [Rust] has? Is [Rust] single-threaded or multi-threaded? Is it synchronous or asynchronous? What are the memory layouts of `Box` and `Vector`? What are a heap and a stack? Where, but on heap and stack data could live in RAM?
 - What runtime [Rust] has? Does it use a GC (garbage collector)?
 - What is special about slice? What is the layout of Rust standard data types? Difference between fat and thin pointers?
 - Why does [Rust] have `&str` and `String` types? How do they differ? When should you use them? Why str slice coexists with slice? What is the difference between `String` and `Vec`?


### PR DESCRIPTION
I have read the questions about single/multithreadiness and sync/async as being related to the memory model of Rust because "it" reference was unclear. I spent much more time than necessary researching the concept of a memory model and its types. Hopefully, this fix will prevent such mistakes in the future.