### PR TITLE
refactor(2_3_bound_impl): replace unsafe `NonZeroU64::new_unchecked` …

### DIFF
--- a/2_idioms/2_3_bound_impl/src/main.rs
+++ b/2_idioms/2_3_bound_impl/src/main.rs
@@ -50,11 +50,7 @@ pub struct EventNumber(NonZeroU64);
 
 impl EventNumber {
     /// The minimum [EventNumber].
-    #[allow(unsafe_code)]
-    pub const MIN_VALUE: EventNumber =
-        // One is absolutely non-zero, and this is required for this to be
-        // usable in a `const` context.
-        EventNumber(unsafe { NonZeroU64::new_unchecked(1) });
+    pub const MIN_VALUE: EventNumber = EventNumber(NonZeroU64::new(1).unwrap());
 
     /// Increments the event number to the next value.
     #[inline]


### PR DESCRIPTION
## Description
Replaces `unsafe` `NonZeroU64::new_unchecked(1)` with safe `NonZeroU64::new(1).unwrap()`.

## Changes
- Remove unsafe code in favor of safe alternative
- Follows Clippy recommendation: [`useless_nonzero_new_unchecked`](https://rust-lang.github.io/rust-clippy/master/index.html#useless_nonzero_new_unchecked)
- No functional changes, only safety improvement