### PR TITLE
NEED REVIEW : Correct workflow yml files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,10 @@ jobs:
   markdown-link:
     name: check (links)
     if: ${{ github.repository_owner == 'instrumentisto' }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.GH_RUNNER_LABEL_CI || 'ubuntu-latest' }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: gaurav-nelson/github-action-markdown-link-check@3c3b66f1f7d0900e37b71eca45b63ea9eedfce31 # 1.0.17
         with:
           config-file: .markdown-link-check.json
           folder-path: ./

--- a/.github/workflows/students_ci.yml
+++ b/.github/workflows/students_ci.yml
@@ -10,13 +10,13 @@ jobs:
   changed_crates:
     if: ${{ github.repository_owner != 'instrumentisto' }}
     name: Detect changes
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.GH_RUNNER_LABEL_CI || 'ubuntu-latest' }}
     outputs:
       has_changes: ${{ steps.crates.outputs.has_changes }}
       crates: ${{ steps.crates.outputs.crates }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # Fetch all history so that git diff can compare against any commit
           fetch-depth: 0
@@ -63,28 +63,26 @@ jobs:
   test:
     needs: changed_crates
     if: ${{ needs.changed_crates.outputs.has_changes == 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.GH_RUNNER_LABEL_CI || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
         crate: ${{ fromJson(needs.changed_crates.outputs.crates) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install Rust
         id: rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master (2026-06-30)
         with:
           toolchain: stable
-          override: true
-          profile: minimal
 
       # Cache dependencies by the crate name and the Rust version
       # It does not save/fetch cache from different crates, because `cargo test -p` does not build them
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
         with:
-          shared-key: ${{ matrix.crate }}-${{ steps.rust.outputs.rustc_hash }}
+          shared-key: ${{ matrix.crate }}-${{ steps.rust.outputs.cachekey }}
 
       - name: Run tests on ${{ matrix.crate }}
         run: cargo test -p ${{ matrix.crate }}

--- a/.github/workflows/students_tool_cache.yml
+++ b/.github/workflows/students_tool_cache.yml
@@ -14,10 +14,10 @@ on:
 jobs:
   cache_tools:
     if: ${{ github.repository_owner != 'instrumentisto' }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.GH_RUNNER_LABEL_CI || 'ubuntu-latest' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Cache dependencies
         uses: ./.github/actions/install-student-ci-deps
 


### PR DESCRIPTION
## Task

Update GitHub Actions workflows to:
- Add the ability to choose a custom (e.g. self-hosted) runner label instead of the hardcoded `ubuntu-latest`.
- Pin all third-party actions to a specific commit SHA instead of a mutable version tag, to protect against supply-chain attacks (a tag can be moved to point at different, possibly malicious, code).

## Solution

- Replaced `runs-on: ubuntu-latest` with `runs-on: ${{ vars.GH_RUNNER_LABEL_CI || 'ubuntu-latest' }}` in `ci.yml`, `students_ci.yml` and `students_tool_cache.yml`. This lets CI switch to a custom runner by setting the `GH_RUNNER_LABEL_CI` repository/organization variable, while still defaulting to `ubuntu-latest` when it's not set (GitHub Actions expressions treat an unset `vars.*` as an empty, falsy string, so `||` works as a default-value operator here).
- Pinned every `uses:` action reference to its full commit SHA, with a `# <version>` comment for readability:
  - `actions/checkout@v3`/`@v4` → `@9c091bb...` (`v7.0.0`)
  - `gaurav-nelson/github-action-markdown-link-check@v1` → `@3c3b66f...` (`1.0.17`) — the `v1` tag turned out to be frozen on a 2022 commit and no longer tracks the maintainer's actual releases.
  - `Swatinem/rust-cache@v2` → `@e18b497...` (`v2.9.1`)
- Replaced `actions-rs/toolchain@v1` with `dtolnay/rust-toolchain` (pinned to SHA), because the `actions-rs` GitHub org was archived in October 2023 and the action is unmaintained (relies on deprecated Node.js runtimes). Updated the dependent cache key from `steps.rust.outputs.rustc_hash` to `steps.rust.outputs.cachekey`, since the new action exposes the cache key under a different output name.